### PR TITLE
update supported react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Louis DeScioli <louis.descioli@gmail.com>"
   ],
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0"
+    "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0"


### PR DESCRIPTION
React 17 is out and some users report peer dependencies warning

```
npm WARN react-clientside-effect@1.2.2 requires a peer of react@^15.3.0 || ^16.0.0 but none is installed. You must install peer dependencies yourself.
```

This update seems to do the trick, but I have not tested it properly