### PR TITLE
Permit React 18 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Louis DeScioli <louis.descioli@gmail.com>"
   ],
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
+    "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.13"


### PR DESCRIPTION
Scanning over the library source, I don't see anything that would be incompatible with React 18, so I think the only necessary change is to the peer deps declaration.