### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Create components whose prop changes map to a global side effect",
   "main": "lib/index.js",
   "module": "lib/index.es.js",
+  "sifeEffects": false,
   "scripts": {
     "build": "node scripts/build.js",
     "clean": "rimraf lib",


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code. Good with esm, modules, named imports.